### PR TITLE
Update pybgpkit to 0.6.2

### DIFF
--- a/bgp/producers/bgpkit/bgpkit2.py
+++ b/bgp/producers/bgpkit/bgpkit2.py
@@ -23,15 +23,15 @@ def delivery_report(err, msg):
 
 def getElementDict(element: dict):
     elementDict = dict()
-    elementDict['type'] = element['elem_type']
-    elementDict['time'] = element['timestamp']
-    elementDict['peer_asn'] = element['peer_asn']
-    elementDict['peer_address'] = element['peer_ip']
+    elementDict['type'] = element.elem_type
+    elementDict['time'] = element.timestamp
+    elementDict['peer_asn'] = element.peer_asn
+    elementDict['peer_address'] = element.peer_ip
     elementDict['fields'] = {
-        'next-hop': element['next_hop'],
-        'as-path': element['as_path'],
-        'communities': list() if not element['communities'] else element['communities'],
-        'prefix': element['prefix']
+        'next-hop': element.next_hop,
+        'as-path': element.as_path,
+        'communities': list() if not element.communities else element.communities,
+        'prefix': element.prefix
     }
     return elementDict
 

--- a/bgp/producers/bgpkit/requirements.txt
+++ b/bgp/producers/bgpkit/requirements.txt
@@ -1,3 +1,3 @@
-pybgpkit==0.5.2
+pybgpkit==0.6.2
 confluent-kafka==2.10.0
 msgpack==1.1.0


### PR DESCRIPTION
This version includes a new version of bgpkit-parser (https://github.com/bgpkit/bgpkit-parser/releases/tag/v0.11.1) which fixes an issue related to missing next-hop fields in some cases.

The way to access the element fields has been changed from a dictionary style to a member style.